### PR TITLE
feat: latest-stable script using curl via GH API

### DIFF
--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# shellcheck source=../lib/utils.bash
+source "$(dirname "$0")/../lib/utils.bash"
+
+curl_opts=(-sI)
+
+if [ -n "${GITHUB_API_TOKEN:-}" ]; then
+	curl_opts=("${curl_opts[@]}" -H "Authorization: token $GITHUB_API_TOKEN")
+fi
+
+# use GitHub releases latest API and follow redirect to resolve final version
+curl "${curl_opts[@]}" "$GH_REPO/releases/latest" |
+	sed -n -e "s|^location: $GH_REPO/releases/tag/||p" |
+	sed -n -e "s|\r||p" |
+	sed 's|^v||'


### PR DESCRIPTION
Adds a `bin/latest-stable` script which to call GitHub API to get latest version.

This is more accurate than the default behaviour which uses `list-all` and `tail` the last version.